### PR TITLE
Change cron times to day time to reduce carbon impact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
   schedule:
     # only run once a week to show the action is working and preserve as much energy as possible
     # Reason being that we pull our ML model and this could have changed in the meantim
-    - cron: '22 4 * * 6'
+    - cron: '22 9 * * 6'
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ name: Daily Tests with Energy Measurement
 run-name: Scheduled - DEV Branch
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 12 * * *'
 
 jobs:
   run-tests:


### PR DESCRIPTION
As described in https://github.com/green-coding-berlin/eco-ci-energy-estimation/issues/32 

This PR will change the default time in the readme from midnight to midday. It also updates the time of one of the actual cron-jobs from 4:22am to 9:22am. The intent is to reduce the carbon output of the action's use by moving the typical schedule to a time of day where the marginal unit of energy has a lower carbon intensity.