### PR TITLE
Adding time to total-data.json and lap-data.json

### DIFF
--- a/scripts/add-data.sh
+++ b/scripts/add-data.sh
@@ -67,9 +67,6 @@ NEW_STEP=$(cat <<EOM
 EOM
 )
 
-
-echo "TIME"
-echo $TIME
 # Add the data point to the JSON file
 if [ -s "$FILE" ]; then
     jq --argjson newstep "$NEW_STEP" '. + $newstep' "$FILE" > tmp.$$.json && mv tmp.$$.json "$FILE"

--- a/scripts/add-data.sh
+++ b/scripts/add-data.sh
@@ -62,7 +62,7 @@ NEW_STEP=$(cat <<EOM
     "cpu_avg_percent": "$CPU",
     "energy_joules": "$ENERGY",
     "power_avg_watts": "$POWER",
-    "time: "$TIME"
+    "time": "$TIME"
 }
 EOM
 )

--- a/scripts/add-data.sh
+++ b/scripts/add-data.sh
@@ -38,6 +38,11 @@ while [[ $# -gt 0 ]]; do
         shift # past argument
         shift # past value
         ;;
+        -t|--time)
+        TIME="$2"
+        shift # past argument
+        shift # past value
+        ;;
         *)  # unknown option
         echo "Unknown option: $1"
         exit 1

--- a/scripts/add-data.sh
+++ b/scripts/add-data.sh
@@ -62,11 +62,14 @@ NEW_STEP=$(cat <<EOM
     "cpu_avg_percent": "$CPU",
     "energy_joules": "$ENERGY",
     "power_avg_watts": "$POWER"
-    "duration: "$TIME"
+    "time: "$TIME"
 }
 EOM
 )
 
+
+echo "TIME"
+echo $TIME
 # Add the data point to the JSON file
 if [ -s "$FILE" ]; then
     jq --argjson newstep "$NEW_STEP" '. + $newstep' "$FILE" > tmp.$$.json && mv tmp.$$.json "$FILE"

--- a/scripts/add-data.sh
+++ b/scripts/add-data.sh
@@ -6,6 +6,7 @@ LABEL=""
 CPU=""
 ENERGY=""
 POWER=""
+TIME=""
 
 # Parse named parameters
 while [[ $# -gt 0 ]]; do
@@ -56,6 +57,7 @@ NEW_STEP=$(cat <<EOM
     "cpu_avg_percent": "$CPU",
     "energy_joules": "$ENERGY",
     "power_avg_watts": "$POWER"
+    "duration: "$TIME"
 }
 EOM
 )

--- a/scripts/add-data.sh
+++ b/scripts/add-data.sh
@@ -61,7 +61,7 @@ NEW_STEP=$(cat <<EOM
     "label": "$LABEL",
     "cpu_avg_percent": "$CPU",
     "energy_joules": "$ENERGY",
-    "power_avg_watts": "$POWER"
+    "power_avg_watts": "$POWER",
     "time: "$TIME"
 }
 EOM

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -146,7 +146,7 @@ function display_results {
     echo "show create-and-add-meta.sh output"
     echo "--file $total_data_file --repository $repo_enc --branch $branch_enc --workflow $WORKFLOW_ID --run_id $run_id_enc"
     source "$(dirname "$0")/create-and-add-meta.sh" --file "${total_data_file}" --repository "${repo_enc}" --branch "${branch_enc}" --workflow "$WORKFLOW_ID" --run_id "${run_id_enc}"
-    source "$(dirname "$0")/add-data.sh" --file "${total_data_file}" --label "TOTAL" --cpu "${cpu_avg}" --energy "${total_energy}" --power "${power_avg}"
+    source "$(dirname "$0")/add-data.sh" --file "${total_data_file}" --label "TOTAL" --cpu "${cpu_avg}" --energy "${total_energy}" --power "${power_avg}" --time "${time}
 
 }
 

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -146,7 +146,7 @@ function display_results {
     echo "show create-and-add-meta.sh output"
     echo "--file $total_data_file --repository $repo_enc --branch $branch_enc --workflow $WORKFLOW_ID --run_id $run_id_enc"
     source "$(dirname "$0")/create-and-add-meta.sh" --file "${total_data_file}" --repository "${repo_enc}" --branch "${branch_enc}" --workflow "$WORKFLOW_ID" --run_id "${run_id_enc}"
-    source "$(dirname "$0")/add-data.sh" --file "${total_data_file}" --label "TOTAL" --cpu "${cpu_avg}" --energy "${total_energy}" --power "${power_avg}" --time "${time}
+    source "$(dirname "$0")/add-data.sh" --file "${total_data_file}" --label "TOTAL" --cpu "${cpu_avg}" --energy "${total_energy}" --power "${power_avg}" --time "${time}"
 
 }
 

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -122,7 +122,7 @@ function make_measurement() {
         echo "--file $lap_data_file --repository $repo_enc --branch $branch_enc --workflow $WORKFLOW_ID --run_id $run_id_enc"
 
         source "$(dirname "$0")/create-and-add-meta.sh" --file "${lap_data_file}" --repository "${repo_enc}" --branch "${branch_enc}" --workflow "$WORKFLOW_ID" --run_id "${run_id_enc}"
-        source "$(dirname "$0")/add-data.sh" --file "${lap_data_file}" --label "$label" --cpu "${cpu_avg}" --energy "${total_energy}" --power "${power_avg}"
+        source "$(dirname "$0")/add-data.sh" --file "${lap_data_file}" --label "$label" --cpu "${cpu_avg}" --energy "${total_energy}" --power "${power_avg}" --time "${time}"
 
         killall -9 -q /tmp/eco-ci/demo-reporter || true
         /tmp/eco-ci/demo-reporter | tee -a /tmp/eco-ci/cpu-util-total.txt > /tmp/eco-ci/cpu-util.txt &


### PR DESCRIPTION
Hi,
I added the `time` (or `duration`) parameter to the data files. I was not sure if this is a desirable feature for anyone else, however I needed this information for my research, and I thought it may be useful for other people too.

What prompted me to add the duration was the discrepancy I noticed between the duration calculated by EcoCI and the duration of the given step provided directly by the GitHub API. I am not sure if this is a big problem, but I wanted to leave this here as well in case it is an uncaught issue.