### PR TITLE
Making display_results work without a prior measurement step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+sftp-config.json

--- a/local_ci.example.sh
+++ b/local_ci.example.sh
@@ -60,9 +60,13 @@ ECO_CI_FORMAT_CLR="\e[44m"
 ECO_CI_TXT_CLEAR="\e[0m"
 
 echo "Dump files"
+echo "/tmp/eco-ci/energy-step.txt"
 cat /tmp/eco-ci/energy-step.txt
+echo "/tmp/eco-ci/cpu-util-step.txt"
 cat /tmp/eco-ci/cpu-util-step.txt
+echo "/tmp/eco-ci/energy-total.txt"
 cat /tmp/eco-ci/energy-total.txt
+echo "/tmp/eco-ci/cpu-util-total.txt"
 cat /tmp/eco-ci/cpu-util-total.txt
 
 $shell "$(dirname "$0")/scripts/display_results.sh" display_results $ECO_CI_DISPLAY_TABLE $ECO_CI_DISPLAY_BADGE

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -66,8 +66,7 @@ function start_measurement {
 
     # this measurement we purely do for the overhead calculation
     if [[ $(wc -l < /tmp/eco-ci/cpu-util-temp.txt) -gt 0 ]]; then
-        source "$(dirname "$0")/make_measurement.sh"
-        make_inference # will populate /tmp/eco-ci/energy-step.txt
+        source "$(dirname "$0")/make_measurement.sh" make_inference # will populate /tmp/eco-ci/energy-step.txt
     fi
 
     # save the values for the overhead


### PR DESCRIPTION
This PR enables Eco-CI work without calling get_measurement but will output everything in display_results