### PR TITLE
Add IP2Location.io API

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ jobs:
           - Send metrics data to metrics.green-coding.io to create and display badge, and see an overview of the energy of your CI runs. Set to false to send no data. The data we send are: the energy value and duration of measurement; cpu model; repository name/branch/workflow_id/run_id; commit_hash; source (GitHub or GitLab). We use this data to display in our green-metrics-tool front-end here: https://metrics.green-coding.io/ci-index.html
         - `calculate-co2`: (optional) (default: true)
           - You might typically always want this value to be shown unless you are in a restricted network and cannot make outbound requests 
-          - Gets the location using https://ipapi.co/
+          - Gets the location using https://ipapi.co/ or https://www.ip2location.io/
           - Get the CO2 grid intensity for the location from https://www.electricitymaps.com/
           - Estimates the amount of carbon the measurement has produced
         - `gh-api-base`: (optional) (default: 'api.github.com')
@@ -148,6 +148,22 @@ You will also need to set it in your workflow files where you call `display-resu
       task: display-results
       pr-comment: true
 
+```
+
+#### IP2LOCATIONIO_API_KEY
+
+You can choose to use IP2Location.io API instead of the default ipapi.co API. You will need a IP2Location.io API Key if you wish to use the API,and you can easily obtain a free one at here: https://www.ip2location.io/sign-up.
+
+You will need to set the API key as a secret `IP2LOCATIONIO_API_KEY`. See the documentation how to do this https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
+
+You will also need to set it in your workflow files, for example:
+```
+      - name: Start Measurement
+        uses: ./
+        env:
+            IP2LOCATIONIO_API_KEY: ${{ secrets.IP2LOCATIONIO_API_KEY }}
+        with:
+          task: start-measurement
 ```
 
 #### Continuing on Errors

--- a/README.md
+++ b/README.md
@@ -149,9 +149,11 @@ You will need to set this token as a secret and pass it in the initalization. To
 
 You will then need to pass it in your workflow files in the initialization. See documentation above.
 
-#### IP2LOCATIONIO_API_KEY
+#### IP2LOCATIONIO API Key
 
 You can choose to use IP2Location.io API instead of the default ipapi.co API. You will need a IP2Location.io API Key if you wish to use the API,and you can easily obtain a free one at here: https://www.ip2location.io/sign-up.
+
+To use IP2Location.io API as the default API, you will first need to add a new variable called `USE_IP2LOCATION_API`. To learn more on how to set up, kindly refer to GitHub documentation to get started: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository.
 
 You will need to set the API key as a secret `IP2LOCATIONIO_API_KEY`. See the documentation how to do this https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
 
@@ -160,6 +162,7 @@ You will also need to set it in your workflow files, for example:
       - name: Start Measurement
         uses: ./
         env:
+            USE_IP2LOCATION_API: ${{ vars.USE_IP2LOCATION_API }}
             IP2LOCATIONIO_API_KEY: ${{ secrets.IP2LOCATIONIO_API_KEY }}
         with:
           task: start-measurement

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ You will then need to pass it in your workflow files in the initialization. See 
 
 You can choose to use IP2Location.io API instead of the default ipapi.co API. You will need a IP2Location.io API Key if you wish to use the API,and you can easily obtain a free one at here: https://www.ip2location.io/sign-up.
 
-To use IP2Location.io API as the default API, you will first need to add a new variable called `USE_IP2LOCATION_API`. To learn more on how to set up, kindly refer to GitHub documentation to get started: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository.
+To use IP2Location.io API as the default API, you will first need to add a new variable called `USE_IP2LOCATION_API`. To learn more on how to set up, kindly refer to GitHub documentation to get started: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository. Set the value of the variable to `true` to use the API.
 
 You will need to set the API key as a secret `IP2LOCATIONIO_API_KEY`. See the documentation how to do this https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
 

--- a/scripts/misc.sh
+++ b/scripts/misc.sh
@@ -4,18 +4,27 @@ set -euo pipefail
 source "$(dirname "$0")/vars.sh"
 
 get_geoip() {
-    if [ -n "${IP2LOCATIONIO_API_KEY}" ]; then
+    USE_IP2LOCATION_API=${USE_IP2LOCATION_API:-false}
+
+    # Check if the IP2Location.io API key is provided and non-empty (after trimming)
+    trimmed_api_key=$(echo "$IP2LOCATIONIO_API_KEY" | xargs)
+    
+    if [ "$USE_IP2LOCATION_API" = "true" ] && [ -n "$trimmed_api_key" ]; then
         echo "Detected IP2Location.io API Key, will use IP2Location.io API key now."
         http_code=$(curl -s -w "%{http_code}" -o /tmp/response_body.txt https://api.ip2location.io/?key=$IP2LOCATIONIO_API_KEY)
         response=$(< /tmp/response_body.txt)
         rm /tmp/response_body.txt
         if echo "$response" | jq '.latitude, .longitude, .city_name, .ip' | grep -q null; then
             echo -e "Required data is missing\nResponse is ${response}\nExiting" >&2
-            return
+            return 1
         fi
         response=$(echo "$response" | jq '. | .city = .city_name | del(.city_name)')
         echo "$response"
     else
+        if [ "$USE_IP2LOCATION_API" = "true" ] && [ -z "$trimmed_api_key" ]; then
+            echo "USE_IP2LOCATION_API is enabled but IP2LOCATIONIO_API_KEY is not provided or contains only spaces. Exiting." >&2
+            return 1
+        fi
         http_code=$(curl -s -w "%{http_code}" -o /tmp/response_body.txt https://ipapi.co/json)
         response=$(< /tmp/response_body.txt)
         rm /tmp/response_body.txt
@@ -27,7 +36,7 @@ get_geoip() {
             rm /tmp/response_body.txt
             if echo "$response" | jq '.latitude, .longitude, .city_name, .ip' | grep -q null; then
                 echo -e "Required data is missing\nResponse is ${response}\nExiting" >&2
-                return
+                return 1
             fi
             response=$(echo "$response" | jq '. | .city = .city_name | del(.city_name)')
         fi


### PR DESCRIPTION
This PR reflected the issue #95. It features 2 updates:

- Add a failover for ipapi.co to use IP2Location.io keyless API if the ipapi.co returned HTTP error code 429 (Refers to [their doc](https://ipapi.co/api/#errors) for more information)
- Add IP2Location.io API which required an API key. If user setup IP2Location.io API key, it will used it to call IP2Location.io API instead of ipapi.co. And also added the steps to add API key in README.md too.

Please let us know if any changes required for this PR. Hope to see the PR gets approved.