### PR TITLE
Alpine requires coreutils to get timestamp in microseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ test-job:
   + Also Windows and macOS are currently not supported.
   + The plugin technically supports large runners, but they will need extra pre-calculated power curved. Contact us if you need them and we are happy to bring them in!
 
+- If you use Alpine, you must install coreutils so that time logging with date is possible with an accuracy of microseconds (`apk add coreutils`)
+
 - If you have your pipelines split over multiple VM's (often the case with many jobs) ,you have to treat each VM as a seperate machine for the purposes of measuring and setting up Eco-CI.
 
 - The underlying [Cloud Energy](https://github.com/green-coding-solutions/cloud-energy) model requires the CPU to have a fixed frequency setting. This is typical for cloud testing and is the case for instance on GitHub, but not always the case in different CIs.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,6 +12,14 @@ function start_measurement {
     fi
     mkdir -p "/tmp/eco-ci"
 
+    # check if date returns a timestamp accurate to microseconds (16 digits)
+    # if not probably coreutils are missing (that's the case with alpine)
+    microseconds=$(date "+%s%6N")
+    if (( ${#microseconds} < 16 )); then
+      echo "ERROR: Date has returned a timestamp that is not accurate to microseconds! You may need to install coreutils."
+      exit 1
+    fi
+
     # start global timer
     date "+%s%6N" > /tmp/eco-ci/timer-total.txt
     cat /tmp/eco-ci/timer-total.txt


### PR DESCRIPTION
Fixes #103

The cause was that the timestamp only had a precision of seconds, not microseconds.

Debugging log statements:
```
step_time_us: 11
step_time_s: 0.00
```

The solution is to install `coreutils` if you are using an Alpine image.

In this PR I included a hint in the README and a check in the script if the timestamp has enough accuracy.
Not sure if the check is ok for you in the way I implemented it (checking the number of digits).