### PR TITLE
Add dependencies to GitLab sample script

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,10 @@ include:
 stages:
   - test
 
+before_script:
+  - apt-get update
+  - apt-get install git jq curl -y # git, jq and curl are dependencies for Eco-CI
+
 test-job:
   stage: test
   script:


### PR DESCRIPTION
In the sample script for GitLab provided in the README the dependencies were missing