### PR TITLE
Totals badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,11 @@ For local testing you can just run in the docker container of your choice, direc
 
 Here is an example with the Circle-CI base image:
 ```bash
-docker run --rm -it -v ./:/tmp/data:ro cimg/base:current bash /tmp/data/local_ci.example.sh
+docker run --network host --rm -it -v ./:/tmp/data:ro cimg/base:current bash /tmp/data/local_ci.example.sh
 ```
+
+In case you are testing with a local installation of the GMT append `--network host` to access `api.green-coding.internal`
+
 
 ### Testing for KDE pipelines
 ```bash

--- a/action.yml
+++ b/action.yml
@@ -74,11 +74,11 @@ inputs:
       default: 'https://api.green-coding.io/v2/ci/measurement/add'
       required: false
   api-endpoint-badge-get:
-      description: 'When using the GMT Dashboard and / or CarbonDB specify the endpoint URL to get the badge from to. Defaults to "https://api.green-coding.io//v1/ci/badge/get'
+      description: 'When using the GMT Dashboard and / or CarbonDB specify the endpoint URL to get the badge from to. Defaults to "https://api.green-coding.io/v1/ci/badge/get'
       default: 'https://api.green-coding.io/v1/ci/badge/get'
       required: false
   dashboard-url:
-      description: 'The URL for the GMT Dashboard. Punch in yours if self-hosted. Defaults to "https://metrics.green-coding.io'
+      description: 'The URL for the GMT Dashboard. Punch in yours if self-hosted. Defaults to "https://metrics.green-coding.io"'
       default: 'https://metrics.green-coding.io'
       required: false
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     default: "github_EPYC_7763_4_CPU_shared.sh"
     required: false
   send-data:
-    description: 'Send metrics data to metrics.green-coding.io to create and display badge, and see an overview of the energy of your CI runs. Set to false to send no data.'
+    description: 'Send metrics data to dashboard (default: metrics.green-coding.io) to create and display badge, and see an overview of the energy of your CI runs. Set to false to send no data.'
     default: true
     required: false
   calculate-co2:
@@ -77,6 +77,11 @@ inputs:
       description: 'When using the GMT Dashboard and / or CarbonDB specify the endpoint URL to get the badge from to. Defaults to "https://api.green-coding.io//v1/ci/badge/get'
       default: 'https://api.green-coding.io/v1/ci/badge/get'
       required: false
+  dashboard-url:
+      description: 'The URL for the GMT Dashboard. Punch in yours if self-hosted. Defaults to "https://metrics.green-coding.io'
+      default: 'https://metrics.green-coding.io'
+      required: false
+
   electricitymaps-api-token:
       description: 'API token for electricitymaps in case you get rate-limited. See documentation for details'
       default: ''
@@ -115,7 +120,7 @@ runs:
         workflow_id=${workflow_id:-"not_set"}
         workflow_name=${workflow_name:-"not_set"}
 
-        ${{github.action_path}}/scripts/setup.sh start_measurement "${{inputs.machine-power-data}}" "${{ github.run_id }}" "${{inputs.branch}}" "${{ github.repository }}" "$workflow_id" "$workflow_name" "${{ github.sha }}" "github" "${{ inputs.send-data }}" "${{ inputs.type }}" "${{ inputs.project }}" "${{ inputs.machine }}" "${{ inputs.tags }}" "${{ inputs.calculate-co2 }}" "${{ inputs.gmt-api-token }}" "${{ inputs.electricitymaps-api-token }}" "${{ inputs.json-output }}" "${{ inputs.api-endpoint-add }}" "${{ inputs.api-endpoint-badge-get }}"
+        ${{github.action_path}}/scripts/setup.sh start_measurement "${{inputs.machine-power-data}}" "${{ github.run_id }}" "${{inputs.branch}}" "${{ github.repository }}" "$workflow_id" "$workflow_name" "${{ github.sha }}" "github" "${{ inputs.send-data }}" "${{ inputs.type }}" "${{ inputs.project }}" "${{ inputs.machine }}" "${{ inputs.tags }}" "${{ inputs.calculate-co2 }}" "${{ inputs.gmt-api-token }}" "${{ inputs.electricitymaps-api-token }}" "${{ inputs.json-output }}" "${{ inputs.api-endpoint-add }}" "${{ inputs.api-endpoint-badge-get }}" "${{ inputs.dashboard-url }}"
 
     - if:  inputs.task == 'get-measurement'
       id: run-lap-model

--- a/eco-ci-gitlab.yml
+++ b/eco-ci-gitlab.yml
@@ -13,6 +13,7 @@ variables:
   ECO_CI_MACHINE_POWER_DATA: "gitlab_EPYC_7B12_saas-linux-small-amd64.sh"
   ECO_CI_API_ENDPOINT_ADD: "https://api.green-coding.io/v2/ci/measurement/add"
   ECO_CI_API_BADGE_GET: "https://api.green-coding.io/v1/ci/badge/get"
+  ECO_CI_DASHBOARD_URL: "https://metrics.green-coding.io"
   ECO_CI_GMT_API_TOKEN: ""
   ECO_CI_ELECTRICITYMAPS_API_TOKEN: ""
 
@@ -25,7 +26,7 @@ variables:
             fi
             git clone --depth 1 --single-branch --branch "${ECO_CI_CLONE_BRANCH}" https://github.com/green-coding-solutions/eco-ci-energy-estimation /tmp/eco-ci-repo
 
-            /tmp/eco-ci-repo/scripts/setup.sh start_measurement "${ECO_CI_MACHINE_POWER_DATA}" "${CI_PIPELINE_ID}" "${CI_COMMIT_REF_NAME}" "${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}" "${CI_PROJECT_ID}" "gitlab-ci.yml" "${CI_COMMIT_SHA}" "gitlab" "${ECO_CI_SEND_DATA}" "${ECO_CI_FILTER_TYPE}" "${ECO_CI_FILTER_PROJECT}" "${ECO_CI_FILTER_MACHINE}" "${ECO_CI_FILTER_TAGS}" "${ECO_CI_CALCULATE_CO2}" "${ECO_CI_GMT_API_TOKEN}" "${ECO_CI_ELECTRICITYMAPS_API_TOKEN}" "${ECO_CI_JSON_OUTPUT}" "${ECO_CI_API_ENDPOINT_ADD}" "${ECO_CI_API_BADGE_GET}"
+            /tmp/eco-ci-repo/scripts/setup.sh start_measurement "${ECO_CI_MACHINE_POWER_DATA}" "${CI_PIPELINE_ID}" "${CI_COMMIT_REF_NAME}" "${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}" "${CI_PROJECT_ID}" "gitlab-ci.yml" "${CI_COMMIT_SHA}" "gitlab" "${ECO_CI_SEND_DATA}" "${ECO_CI_FILTER_TYPE}" "${ECO_CI_FILTER_PROJECT}" "${ECO_CI_FILTER_MACHINE}" "${ECO_CI_FILTER_TAGS}" "${ECO_CI_CALCULATE_CO2}" "${ECO_CI_GMT_API_TOKEN}" "${ECO_CI_ELECTRICITYMAPS_API_TOKEN}" "${ECO_CI_JSON_OUTPUT}" "${ECO_CI_API_ENDPOINT_ADD}" "${ECO_CI_API_BADGE_GET}" "${ECO_CI_DASHBOARD_URL}"
 
 .get_measurement:
     script:

--- a/local_ci.example.sh
+++ b/local_ci.example.sh
@@ -7,7 +7,7 @@ ECO_CI_SEND_DATA='true'
 ECO_CI_DISPLAY_BADGE='true'
 ECO_CI_DISPLAY_TABLE='true'
 
-ECO_CI_WORKFLOW_ID='YOUR WORKFLOW ID'
+ECO_CI_WORKFLOW_ID='YOUR_WORKFLOW_ID'
 
 # If you want filter data in the GMT Dashboard or in CarbonDB you can here manually set data for drill-down later
 # The values given are just some default recommendations

--- a/local_ci.example.sh
+++ b/local_ci.example.sh
@@ -23,8 +23,9 @@ ECO_CI_GMT_API_TOKEN=''
 ECO_CI_ELECTRICITYMAPS_API_TOKEN=''
 
 # Change this to a local installation of the GMT if you have
-ECO_CI_API_ENDPOINT_ADD='https://api.green-coding.io/v2/ci/measurement/add'
-ECO_CI_API_BADGE_GET='https://api.green-coding.io/v1/ci/badge/get'
+ECO_CI_API_ENDPOINT_ADD='http://api.green-coding.internal:9142/v2/ci/measurement/add'
+ECO_CI_API_BADGE_GET='http://api.green-coding.internal:9142/v1/ci/badge/get'
+ECO_CI_DASHBOARD_URL='http://metrics.green-coding.internal:9142'
 
 # Use a generated power curve from Cloud Energy here
 ECO_CI_MACHINE_POWER_DATA="default.sh"
@@ -32,7 +33,7 @@ ECO_CI_MACHINE_POWER_DATA="default.sh"
 # Initialize
 echo "Initialize"
 
-$shell "$(dirname "$0")/scripts/setup.sh" start_measurement "$ECO_CI_MACHINE_POWER_DATA" "MY_RUN_ID" "NO_BRANCH" "LOCAL_TEST_REPO" "$ECO_CI_WORKFLOW_ID" "MY WORKFLOW NAME" "NO SHA" "local" "$ECO_CI_SEND_DATA" "$ECO_CI_FILTER_TYPE" "$ECO_CI_FILTER_PROJECT" "$ECO_CI_FILTER_MACHINE" "$ECO_CI_FILTER_TAGS" "$ECO_CI_CALCULATE_CO2" "$ECO_CI_GMT_API_TOKEN" "$ECO_CI_ELECTRICITYMAPS_API_TOKEN" "$ECO_CI_JSON_OUTPUT" "$ECO_CI_API_ENDPOINT_ADD" "$ECO_CI_API_BADGE_GET"
+$shell "$(dirname "$0")/scripts/setup.sh" start_measurement "$ECO_CI_MACHINE_POWER_DATA" "MY_RUN_ID" "NO_BRANCH" "LOCAL_TEST_REPO" "$ECO_CI_WORKFLOW_ID" "MY WORKFLOW NAME" "NO SHA" "local" "$ECO_CI_SEND_DATA" "$ECO_CI_FILTER_TYPE" "$ECO_CI_FILTER_PROJECT" "$ECO_CI_FILTER_MACHINE" "$ECO_CI_FILTER_TAGS" "$ECO_CI_CALCULATE_CO2" "$ECO_CI_GMT_API_TOKEN" "$ECO_CI_ELECTRICITYMAPS_API_TOKEN" "$ECO_CI_JSON_OUTPUT" "$ECO_CI_API_ENDPOINT_ADD" "$ECO_CI_API_BADGE_GET" "$ECO_CI_DASHBOARD_URL"
 
 echo "Duration: "$(($(date "+%s%6N") - $(cat /tmp/eco-ci/timer-total.txt))) "us"
 

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -67,6 +67,8 @@ function display_results {
         fi
     fi
 
+    repo_enc=$( echo ${ECO_CI_REPOSITORY} | jq -Rr @uri)
+    branch_enc=$( echo ${ECO_CI_BRANCH} | jq -Rr @uri)
 
     if [[ ${ECO_CI_CALCULATE_CO2} == 'true' ]]; then
         source "$(dirname "$0")/misc.sh"
@@ -100,17 +102,14 @@ function display_results {
     fi
 
     if [[ "${ECO_CI_SEND_DATA}" == 'true' && "${display_badge}" == 'true' ]]; then
-        repo_enc=$( echo ${ECO_CI_REPOSITORY} | jq -Rr @uri)
-        branch_enc=$( echo ${ECO_CI_BRANCH} | jq -Rr @uri)
-        metrics_url='https://metrics.green-coding.io'
-
         echo "Badge for your README.md:" >> $output
         echo ' ```' >> $output
-        echo "[![Energy Used](${ECO_CI_API_ENDPOINT_BADGE_GET}?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID})](${metrics_url}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID})" >> $output
+        echo "[![Energy Used](${ECO_CI_API_ENDPOINT_BADGE_GET}?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID})](${ECO_CI_DASHBOARD_URL}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID})" >> $output
+        echo "[![Carbon emitted](${ECO_CI_API_ENDPOINT_BADGE_GET}?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID})](${ECO_CI_DASHBOARD_URL}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}&metric=carbon)" >> $output
         echo ' ```' >> $output
 
         echo 'See energy runs here:' >> $output
-        echo "${metrics_url}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=$WORKFLOW_ID" >> $output
+        echo "${ECO_CI_DASHBOARD_URL}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=$WORKFLOW_ID" >> $output
     fi
 
     if [[ ${ECO_CI_JSON_OUTPUT} == 'true' ]]; then

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -11,10 +11,6 @@ function display_results {
 
     # First get values, in case any are unbound
     # this will set them to an empty string if they are missing entirely
-    MEASUREMENT_RAN=${ECO_CI_MEASUREMENT_RAN:-}
-    MEASUREMENT_COUNT=${ECO_CI_MEASUREMENT_COUNT:-}
-    WORKFLOW_ID=${ECO_CI_WORKFLOW_ID:-}
-    JSON_OUTPUT=${ECO_CI_JSON_OUTPUT:-}
     GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-}
 
     output='/tmp/eco-ci/output.txt'
@@ -97,8 +93,8 @@ function display_results {
 
             if [[ "${display_badge}" == 'true' ]]; then
                 echo "Total cost of whole PR so far:<br>"
-                echo "<a href="${ECO_CI_DASHBOARD_URL}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}"><img src="${ECO_CI_API_ENDPOINT_BADGE_GET}?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}&mode=totals&metric=energy"></a>" | tee -a $output $output_pr
-                echo "<a href="${ECO_CI_DASHBOARD_URL}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}"><img src="${ECO_CI_API_ENDPOINT_BADGE_GET}?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}&mode=totals&metric=carbon"></a>" | tee -a $output $output_pr
+                echo "<a href='${ECO_CI_DASHBOARD_URL}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}'><img src='${ECO_CI_API_ENDPOINT_BADGE_GET}?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}&mode=totals&metric=energy'></a>" | tee -a $output $output_pr
+                echo "<a href='${ECO_CI_DASHBOARD_URL}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}'><img src='${ECO_CI_API_ENDPOINT_BADGE_GET}?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}&mode=totals&metric=carbon'></a>" | tee -a $output $output_pr
             fi
         else
             echo '❌ CO2 Data:' | tee -a $output $output_pr
@@ -115,7 +111,7 @@ function display_results {
         echo ' ```' >> $output
 
         echo 'See energy runs here:' >> $output
-        echo "${ECO_CI_DASHBOARD_URL}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=$WORKFLOW_ID" >> $output
+        echo "${ECO_CI_DASHBOARD_URL}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}" >> $output
     fi
 
     if [[ ${ECO_CI_JSON_OUTPUT} == 'true' ]]; then

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -63,8 +63,8 @@ function display_results {
         fi
     fi
 
-    repo_enc=$( echo ${ECO_CI_REPOSITORY} | jq -Rr @uri)
-    branch_enc=$( echo ${ECO_CI_BRANCH} | jq -Rr @uri)
+    repo_enc=$( echo "${ECO_CI_REPOSITORY}" | jq -Rr @uri)
+    branch_enc=$( echo "${ECO_CI_BRANCH}" | jq -Rr @uri)
 
     if [[ ${ECO_CI_CALCULATE_CO2} == 'true' ]]; then
         source "$(dirname "$0")/misc.sh"
@@ -89,7 +89,7 @@ function display_results {
             echo "CO₂ from energy is: ${ECO_CI_CO2EQ_ENERGY} g" | tee -a $output $output_pr
             echo "CO₂ from manufacturing (embodied carbon) is: ${ECO_CI_CO2EQ_EMBODIED} g" | tee -a $output $output_pr
             echo "<a href='https://www.electricitymaps.com/methodology#carbon-intensity-and-emission-factors' target=_blank rel=noopener>Carbon Intensity</a> for this location: <b>${ECO_CI_CO2I} gCO₂eq/kWh</b>" | tee -a $output $output_pr
-            printf "<a href='https://sci-guide.greensoftware.foundation/'  target=_blank rel=noopener>SCI</a>: <b>%.6f gCO₂eq / pipeline run</b> emitted\n" ${ECO_CI_CO2EQ} | tee -a $output $output_pr
+            printf "<a href='https://sci-guide.greensoftware.foundation/'  target=_blank rel=noopener>SCI</a>: <b>%.6f gCO₂eq / pipeline run</b> emitted\n" "${ECO_CI_CO2EQ}" | tee -a $output $output_pr
 
             if [[ "${display_badge}" == 'true' ]]; then
                 echo "Total cost of whole PR so far:<br>"

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -94,6 +94,12 @@ function display_results {
             echo "CO₂ from manufacturing (embodied carbon) is: ${ECO_CI_CO2EQ_EMBODIED} g" | tee -a $output $output_pr
             echo "<a href='https://www.electricitymaps.com/methodology#carbon-intensity-and-emission-factors' target=_blank rel=noopener>Carbon Intensity</a> for this location: <b>${ECO_CI_CO2I} gCO₂eq/kWh</b>" | tee -a $output $output_pr
             printf "<a href='https://sci-guide.greensoftware.foundation/'  target=_blank rel=noopener>SCI</a>: <b>%.6f gCO₂eq / pipeline run</b> emitted\n" ${ECO_CI_CO2EQ} | tee -a $output $output_pr
+
+            if [[ "${display_badge}" == 'true' ]]; then
+                echo "Total cost of whole PR so far:<br>"
+                echo "<a href="${ECO_CI_DASHBOARD_URL}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}"><img src="${ECO_CI_API_ENDPOINT_BADGE_GET}?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}&mode=totals&metric=energy"></a>" | tee -a $output $output_pr
+                echo "<a href="${ECO_CI_DASHBOARD_URL}/ci.html?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}"><img src="${ECO_CI_API_ENDPOINT_BADGE_GET}?repo=${repo_enc}&branch=${branch_enc}&workflow=${ECO_CI_WORKFLOW_ID}&mode=totals&metric=carbon"></a>" | tee -a $output $output_pr
+            fi
         else
             echo '❌ CO2 Data:' | tee -a $output $output_pr
             echo 'Error in retrieving values. Please see the detailed logs for the exact error messages!' | tee -a $output $output_pr

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -6,8 +6,9 @@ source "$(dirname "$0")/vars.sh"
 read_vars
 
 function make_inference() {
+    # First get values, in case any are unbound
+    # this will set them to an empty string if they are missing entirely
     BASH_VERSION=${BASH_VERSION:-}
-    ECO_CI_MACHINE_POWER_DATA=${ECO_CI_MACHINE_POWER_DATA:-}
 
     # clear energy file for step because we fill it later anew
     echo > /tmp/eco-ci/energy-step.txt

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -103,7 +103,6 @@ function make_measurement() {
               tags_as_json_list=$(echo "\"${ECO_CI_FILTER_TAGS}\"" | sed s/,/\",\"/g)
             fi
 
-
             curl -X POST "${ECO_CI_API_ENDPOINT_ADD}" \
                 -H 'Content-Type: application/json' \
                 -H "X-Authentication: ${ECO_CI_GMT_API_TOKEN}" \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -47,6 +47,7 @@ function start_measurement {
     add_var 'ECO_CI_JSON_OUTPUT' "${17}"
     add_var 'ECO_CI_API_ENDPOINT_ADD' "${18}"
     add_var 'ECO_CI_API_ENDPOINT_BADGE_GET' "${19}"
+    add_var 'ECO_CI_DASHBOARD_URL' "${20}"
 
     touch /tmp/eco-ci/cpu-util-step.txt
     touch /tmp/eco-ci/cpu-util-total.txt
@@ -102,7 +103,7 @@ fi
 
 case $option in
   start_measurement)
-    start_measurement "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "${11}" "${12}" "${13}" "${14}" "${15}" "${16}" "${17}" "${18}" "${19}" "${20}"
+    start_measurement "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "${11}" "${12}" "${13}" "${14}" "${15}" "${16}" "${17}" "${18}" "${19}" "${20}" "${21}"
     ;;
   lap_measurement)
     lap_measurement


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR adds totals badge functionality and improves dashboard URL configuration in the Eco-CI Energy Estimation tool.

- Added totals badge display in `scripts/display_results.sh` showing aggregate energy and carbon metrics
- Added configurable `dashboard-url` parameter in `action.yml` defaulting to metrics.green-coding.io
- Updated URL formatting in badge endpoints to remove double forward slashes
- Added support for local GMT installations with internal testing URLs in `local_ci.example.sh`
- Improved error handling and variable quoting in measurement scripts



<!-- /greptile_comment -->