### PR TITLE
Hotfix Linux: Different kill mechanism

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -105,7 +105,7 @@ function end_measurement {
     if [[ $(uname) == "Darwin" ]]; then
         kill_tree $(pgrep -f "$(dirname "$0")/cpu-utilization-macos.sh" || true)
     else
-        kill_tree $(pgrep -f "$(dirname "$0")/cpu-utilization-linux.sh" || true)
+        pkill -SIGTERM -f "$(dirname "$0")/cpu-utilization-linux.sh"  || true;
     fi
 }
 


### PR DESCRIPTION
We have seen runs having multiple kW which was due to truncation in the output of the CPU utilization stream
![Screenshot 2025-02-12 at 11 30 21 AM](https://github.com/user-attachments/assets/0309f85e-2148-49b7-910a-3a9123c8a258)

https://github.com/green-coding-solutions/argopy/actions/runs/13259456675

This hotfix kills the process more gracefully and thus truncation should not occur.

<!-- greptile_comment -->

## Greptile Summary

This PR modifies the process termination mechanism in `setup.sh` to address an issue where truncated CPU utilization data was causing incorrect energy measurements in the kWh range.

- Replaces recursive `kill_tree` function with `pkill -SIGTERM` for Linux CPU monitoring termination
- Keeps original `kill_tree` function for macOS process termination
- Fixes critical bug where truncated CPU utilization output led to inflated energy measurements
- Provides more graceful process termination to prevent data corruption during measurement collection



<!-- /greptile_comment -->