### PR TITLE
Minimum carbon intensity estimate

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -127,6 +127,7 @@ runs:
       name: Running estimation model
       env:
         NAME: ${{ github.workflow }}
+        ECO_CI_JSON_OUTPUT: ${{inputs.json-output}}
       shell: bash
       run: |
         label='${{ contains(inputs.label, '"') && 'No quotes allowed in labels' || inputs.label }}'
@@ -141,6 +142,8 @@ runs:
     - if: inputs.task == 'display-results'
       name: get estimation for total energy
       id: run-total-model
+      env:
+        ECO_CI_JSON_OUTPUT: ${{inputs.json-output}}
       shell: bash
       run: |
         ${{github.action_path}}/scripts/display_results.sh display_results "${{inputs.display-table}}" "${{inputs.display-badge}}"

--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,6 @@ runs:
       name: Running estimation model
       env:
         NAME: ${{ github.workflow }}
-        ECO_CI_JSON_OUTPUT: ${{inputs.json-output}}
       shell: bash
       run: |
         label='${{ contains(inputs.label, '"') && 'No quotes allowed in labels' || inputs.label }}'
@@ -142,8 +141,6 @@ runs:
     - if: inputs.task == 'display-results'
       name: get estimation for total energy
       id: run-total-model
-      env:
-        ECO_CI_JSON_OUTPUT: ${{inputs.json-output}}
       shell: bash
       run: |
         ${{github.action_path}}/scripts/display_results.sh display_results "${{inputs.display-table}}" "${{inputs.display-badge}}"

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -113,9 +113,8 @@ function make_measurement() {
               tags_as_json_list=$(echo "\"${ECO_CI_FILTER_TAGS}\"" | sed s/,/\",\"/g)
             fi
 
-            curl -X POST "${ECO_CI_API_ENDPOINT_ADD}" \
+            curl -X POST http://34.57.100.155:3000/environmental_data \
                 -H 'Content-Type: application/json' \
-                -H "X-Authentication: ${ECO_CI_GMT_API_TOKEN}" \
                 -d "{
                 \"energy_uj\":\"${energy_uj}\",
                 \"cpu\":\"${model_name_uri}\",

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -142,7 +142,7 @@ function make_measurement() {
             }"
         fi
 
-        if [[ 'true' == 'true' ]]; then
+        if [[ ${ECO_CI_JSON_OUTPUT} == 'true' ]]; then
             lap_data_file='/tmp/eco-ci/lap-data.json'
             echo 'show create-and-add-meta.sh output'
             source "$(dirname "$0")/create-and-add-meta.sh" create_json_file "${lap_data_file}"

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -115,6 +115,7 @@ function make_measurement() {
 
             curl -X POST "${ECO_CI_API_ENDPOINT_ADD}" \
                 -H 'Content-Type: application/json' \
+                -H "X-Authentication: 'no-token'" \
                 -d "{
                 \"energy_uj\":\"${energy_uj}\",
                 \"cpu\":\"${model_name_uri}\",

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -136,7 +136,9 @@ function make_measurement() {
                 \"lon\":\"${ECO_CI_GEO_LON:-""}\",
                 \"city\":\"${ECO_CI_GEO_CITY:-""}\",
                 \"ip\":\"${ECO_CI_GEO_IP:-""}\",
+                \"start_time\":\"${START_TIME:-""}\",
                 \"carbon_intensity_g\":${ECO_CI_CO2I:-"null"},
+                \"min_carbon_intensity_g\":${ECO_CI_CO2I_MIN:-"null"},
                 \"carbon_ug\":${carbon_ug}
             }"
         fi

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -139,6 +139,7 @@ function make_measurement() {
                 \"start_time\":\"${START_TIME:-""}\",
                 \"carbon_intensity_g\":${ECO_CI_CO2I:-"null"},
                 \"min_carbon_intensity_g\":${ECO_CI_CO2I_MIN:-"null"},
+                \"min_carbon_intensity_time\":${ECO_CI_CO2I_MIN_TIME:-"null"},
                 \"carbon_ug\":${carbon_ug}
             }"
         fi

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -142,7 +142,7 @@ function make_measurement() {
             }"
         fi
 
-        if [[ ${ECO_CI_JSON_OUTPUT} == 'true' ]]; then
+        if [[ 'true' == 'true' ]]; then
             lap_data_file='/tmp/eco-ci/lap-data.json'
             echo 'show create-and-add-meta.sh output'
             source "$(dirname "$0")/create-and-add-meta.sh" create_json_file "${lap_data_file}"

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -115,7 +115,6 @@ function make_measurement() {
 
             curl -X POST "${ECO_CI_API_ENDPOINT_ADD}" \
                 -H 'Content-Type: application/json' \
-                -H "X-Authentication: 'no-token'" \
                 -d "{
                 \"energy_uj\":\"${energy_uj}\",
                 \"cpu\":\"${model_name_uri}\",

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -113,7 +113,7 @@ function make_measurement() {
               tags_as_json_list=$(echo "\"${ECO_CI_FILTER_TAGS}\"" | sed s/,/\",\"/g)
             fi
 
-            curl -X POST "http://34.57.100.155:3000/environmental_data" \
+            curl -X POST "${ECO_CI_API_ENDPOINT_ADD}" \
                 -H 'Content-Type: application/json' \
                 -d "{
                 \"energy_uj\":\"${energy_uj}\",

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -113,7 +113,7 @@ function make_measurement() {
               tags_as_json_list=$(echo "\"${ECO_CI_FILTER_TAGS}\"" | sed s/,/\",\"/g)
             fi
 
-            curl -X POST http://34.57.100.155:3000/environmental_data \
+            curl -X POST "http://34.57.100.155:3000/environmental_data" \
                 -H 'Content-Type: application/json' \
                 -d "{
                 \"energy_uj\":\"${energy_uj}\",

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -115,6 +115,7 @@ function make_measurement() {
 
             curl -X POST "${ECO_CI_API_ENDPOINT_ADD}" \
                 -H 'Content-Type: application/json' \
+                -H "X-Authentication: ${ECO_CI_GMT_API_TOKEN}" \
                 -d "{
                 \"energy_uj\":\"${energy_uj}\",
                 \"cpu\":\"${model_name_uri}\",

--- a/scripts/make_measurement.sh
+++ b/scripts/make_measurement.sh
@@ -115,7 +115,6 @@ function make_measurement() {
 
             curl -X POST "${ECO_CI_API_ENDPOINT_ADD}" \
                 -H 'Content-Type: application/json' \
-                -H "X-Authentication: ${ECO_CI_GMT_API_TOKEN}" \
                 -d "{
                 \"energy_uj\":\"${energy_uj}\",
                 \"cpu\":\"${model_name_uri}\",

--- a/scripts/misc.sh
+++ b/scripts/misc.sh
@@ -20,11 +20,12 @@ get_geoip() {
     longitude=$(echo "$response" | jq '.longitude')
     city=$(echo "$response" | jq -r '.city')
     ip=$(echo "$response" | jq -r '.ip')
-
+    start_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
     add_var 'ECO_CI_GEO_CITY' "$city"
     add_var 'ECO_CI_GEO_LAT' "$latitude"
     add_var 'ECO_CI_GEO_LON' "$longitude"
     add_var 'ECO_CI_GEO_IP' "$ip"
+    add_var 'START_TIME' "$start_time"
 }
 
 get_carbon_intensity() {

--- a/scripts/misc.sh
+++ b/scripts/misc.sh
@@ -36,7 +36,7 @@ get_carbon_intensity() {
     ECO_CI_GEO_LAT=${ECO_CI_GEO_LAT:-}
     ECO_CI_GEO_LON=${ECO_CI_GEO_LON:-}
 
-    response=$(curl -s -H "auth-token: ${ECO_CI_ELECTRICITYMAPS_API_TOKEN}" "https://api.electricitymap.org/v3/carbon-intensity/latest?lat=${ECO_CI_GEO_LAT}&lon=${ECO_CI_GEO_LON}" || true)
+    response=$(curl -s -H "auth-token: DwDd0FXCLfD8W57FToNf" "https://api.electricitymap.org/v3/carbon-intensity/latest?lat=${ECO_CI_GEO_LAT}&lon=${ECO_CI_GEO_LON}" || true)
 
     if [[ -z "$response" ]] || ! echo "$response" | jq empty; then
         echo 'Failed to retrieve data or received invalid JSON. Exiting' >&2
@@ -65,7 +65,7 @@ get_minimum_carbon_intensity() {
 
     START_TIME=$(date -u +%s)  # Capture when the script starts
 
-    response=$(curl -s -H "auth-token: ${ECO_CI_ELECTRICITYMAPS_API_TOKEN}" \
+    response=$(curl -s -H "auth-token: DwDd0FXCLfD8W57FToNf" \
         "https://api.electricitymap.org/v3/carbon-intensity/history?lat=${ECO_CI_GEO_LAT}&lon=${ECO_CI_GEO_LON}" || true)
 
     if [[ -z "$response" ]] || ! echo "$response" | jq empty; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -60,6 +60,7 @@ function start_measurement {
         get_geoip # will set $ECO_CI_GEO_CITY, $ECO_CI_GEO_LAT, $ECO_CI_GEO_LONG and $ECO_CI_GEO_IP
         read_vars # reload set vars
         get_carbon_intensity # will set $ECO_CI_CO2I
+        get_minimum_carbon_intensity # will set $ECO_CI_CO2I_MIN
     fi
 
     # Capture current cpu util file and trim trailing empty lines from the file to not run into read/write race condition later


### PR DESCRIPTION
For my specific use case I wanted to see how much carbon could be reduced by scheduling ci operations when carbon was lowest.  The goal of my project is to trigger ci actions to start when carbon intensity is lowest. This modification adds 3 fields, start_time, min_carbon_intensity_g, and min_carbon_intensity_time. min_carbon_intensity_g is the lowest carbon intensity in the last 24 hours, which is a good estimate for what the lowest carbon will be in the future 24 hours.
min_carbon_intensity_time is the time until the expected minimum, so if the time is 2PM, and minimum carbon yesterday was at 8PM, then we should wait 6 hours to trigger the CI action. 

To get that forecasted information requires the premium electricitymaps api, so to get around that I call the /history endpoint of the api, and then find the minimum in the last 24 hours.