### PR TITLE
macOS Hotfix for CPU utilization

### DIFF
--- a/scripts/cpu-utilization-macos.sh
+++ b/scripts/cpu-utilization-macos.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # By ChatGPT and masterfully adapted by Arne Tarara. No rights reserved :)
 
-iostat -w 1 | awk -v date_cmd="gdate +%s%N" '
+iostat -w 1 -n 0 | awk -v date_cmd="gdate +%s%N" '
 NR > 3 { # skips first 3 rows, which contain header data and first average-only measurement
     # Extract user, system, and idle CPU percentages
-    user = $3
-    sys = $4
-    idle = $6
+    user = $1
+    sys = $2
+    idle = $3
 
     # Calculate total CPU usage
     usage = 100 - idle
@@ -25,7 +25,6 @@ NR > 3 { # skips first 3 rows, which contain header data and first average-only 
 
     # Print the time and CPU usage
     printf "%.10f %.2f\n", (time_diff_ns / 1000000000), usage
-
 
     # Store the current time as the last time for the next iteration
     last_time_ns = current_time_ns


### PR DESCRIPTION
Systems on macOS can have multiple disks.

While writing the inital code the location of the USER, SYSTEM and IDLE values was somehow different.

Now we use a robust command that omits all disks to locate positions of the relevant CPU utilization params

<!-- greptile_comment -->

## Greptile Summary

This PR fixes CPU utilization measurement on macOS systems by ensuring consistent field positions for CPU metrics regardless of disk configuration.

- Added `-n 0` flag to `iostat` command to omit disk information, ensuring only CPU statistics are processed
- Updated field indices for user, system, and idle CPU percentages from $3, $4, $6 to $1, $2, $3 respectively
- Ensures accurate energy estimation by preventing incorrect CPU utilization readings on systems with multiple disks



<!-- /greptile_comment -->