### PR TITLE
Adding Run-ID to Eco CI Output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -179,8 +179,7 @@ runs:
               echo 'Skipping already collapsed Eco CI comment'
               continue
             fi
-
-            if [[ "$COMMENT_BODY" == *"Eco CI Output [RUN-ID: $RUN-ID]:"* ]]; then
+            if [[ "$COMMENT_BODY" == *"Eco CI Output [RUN-ID: ${RUN_ID}]:"* ]]; then
               echo 'Skipping Eco CI comment from same RUN-ID'
               continue
             fi

--- a/action.yml
+++ b/action.yml
@@ -160,19 +160,35 @@ runs:
       shell: bash
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        RUN_ID: ${{ github.run_id }}
       run: |
         echo 'Running PR-Comment task'
         COMMENTS=$(curl -s -H  "Authorization: Bearer ${{github.token}}" "${{ inputs.gh-api-base }}/repos/${{ github.repository }}/issues/$PR_NUMBER/comments")
 
-        echo "$COMMENTS" | jq -c --arg username "github-actions[bot]" '.[] | select(.user.login == $username and (.body | index("Eco CI") // false))' | while read -r comment; do
+        echo "$COMMENTS" | jq -c --arg username "github-actions[bot]" '.[] | select(.user.login == $username)' | while read -r comment; do
+
             COMMENT_ID=$(echo "$comment" | jq -r '.id')
             COMMENT_BODY=$(echo "$comment" | jq -r '.body')
-            INNER_BODY=$(echo "$COMMENT_BODY" | sed 's/<details><summary>Old Energy Estimation<\/summary>//g' | sed 's/<\/details>//g')
+
+            if [[ "$COMMENT_BODY" != *"Eco CI Output [RUN-ID:"* ]]; then
+              echo 'Skipping non Eco CI comment'
+              continue
+            fi
+
+            if [[ "$COMMENT_BODY" == *"Eco CI Output - Old Energy Estimation"* ]]; then
+              echo 'Skipping already collapsed Eco CI comment'
+              continue
+            fi
+
+            if [[ "$COMMENT_BODY" == *"Eco CI Output [RUN-ID: $RUN-ID]:"* ]]; then
+              echo 'Skipping Eco CI comment from same RUN-ID'
+              continue
+            fi
 
             ## indentation here is important, otherwise newlines are not properly sent/processed
-            PAYLOAD=$(jq --null-input --arg body "<details><summary>Old Energy Estimation</summary>
+            PAYLOAD=$(jq --null-input --arg body "<details><summary>Eco CI Output - Old Energy Estimation</summary>
 
-        $INNER_BODY
+        $COMMENT_BODY
 
         </details>" '{"body": $body}')
             curl -s -H "Authorization: Bearer ${{github.token}}" -X PATCH -d "$PAYLOAD" "${{ inputs.gh-api-base }}/repos/${{ github.repository }}/issues/comments/$COMMENT_ID"

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -34,7 +34,7 @@ function display_results {
         ## Used for the main output display for github (step summary) / gitlab (artifacts)
 
         if [[ "$ECO_CI_SOURCE" != 'gitlab' ]]; then
-                echo "Eco CI Output: " >> $output_pr
+                echo "Eco CI Output [RUN-ID: ${ECO_CI_RUN_ID}]: " >> $output_pr
                 echo "|Label|🖥 avg. CPU utilization [%]|🔋 Total Energy [Joules]|🔌 avg. Power [Watts]|Duration [Seconds]|" | tee -a $output $output_pr
                 echo "|---|---|---|---|---|" | tee -a $output $output_pr
         fi


### PR DESCRIPTION
This PR reduced complexity in how comment processing is done by skipping already collapsed comments and unrolling the complicated `jq` query.

Furthermore this PR does not collapse comments from the same run anymore

<!-- greptile_comment -->

## Greptile Summary

This PR modifies the display_results.sh script to include RUN-ID in output headers and simplifies comment processing logic for GitHub PR comments.

- Added RUN-ID to output header in `/scripts/display_results.sh` for better CI run tracking
- Simplified comment processing by skipping already collapsed comments
- Modified logic to prevent collapsing comments from the same run
- Streamlined `jq` query complexity in PR comment handling



<!-- /greptile_comment -->