### PR TITLE
Add variable to specify metrics.txt directory in GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ artifacts:
       metrics: metrics.txt
 ```
 
+By default, metrics.txt is copied into [`$CI_PROJECT_DIR`](https://docs.gitlab.com/ci/variables/predefined_variables/#predefined-variables). If necessary, the target location of all artifacts can be adjusted in [`eco-ci-gitlab.yml`](https://github.com/green-coding-solutions/eco-ci-energy-estimation/blob/main/eco-ci-gitlab.yml) using appropriate copy commands.
+
 #### Gitlab sample file
 
 Please look at [.gitlab-ci.yml.example](.gitlab-ci.yml.example)

--- a/eco-ci-gitlab.yml
+++ b/eco-ci-gitlab.yml
@@ -41,5 +41,5 @@ variables:
             FORMAT_CLR="\e[44m" && TXT_CLEAR="\e[0m"
             /tmp/eco-ci-repo/scripts/display_results.sh display_results "${ECO_CI_DISPLAY_TABLE}" "${ECO_CI_DISPLAY_BADGE}"
             echo -e "$FORMAT_CLR$(cat /tmp/eco-ci/output.txt)$TXT_CLEAR"
-            cp /tmp/eco-ci/output.txt ./eco-ci-output.txt
+            cp /tmp/eco-ci/output.txt "${CI_PROJECT_DIR}/eco-ci-output.txt"
             cp /tmp/eco-ci/metrics.txt "${CI_PROJECT_DIR}/metrics.txt"

--- a/eco-ci-gitlab.yml
+++ b/eco-ci-gitlab.yml
@@ -42,3 +42,4 @@ variables:
             /tmp/eco-ci-repo/scripts/display_results.sh display_results "${ECO_CI_DISPLAY_TABLE}" "${ECO_CI_DISPLAY_BADGE}"
             echo -e "$FORMAT_CLR$(cat /tmp/eco-ci/output.txt)$TXT_CLEAR"
             cp /tmp/eco-ci/output.txt ./eco-ci-output.txt
+            cp /tmp/eco-ci/metrics.txt "${CI_PROJECT_DIR}/metrics.txt"

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -14,6 +14,7 @@ function display_results {
     GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-}
 
     local output='/tmp/eco-ci/output.txt'
+	local gitlab_metrics_file="${CI_PROJECT_DIR}/metrics.txt"
     local output_pr='/tmp/eco-ci/output-pr.txt'
 
     if [[ $(wc -l < /tmp/eco-ci/energy-total.txt) -eq 0 ]]; then
@@ -42,10 +43,10 @@ function display_results {
         for (( i=1; i<=$ECO_CI_MEASUREMENT_COUNT; i++ )); do
             if [[ "$ECO_CI_SOURCE" == 'gitlab' ]]; then
                     # CI_JOB_NAME is a set variable by GitLab
-                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Energy Used [Joules]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_ENERGY)" | tee -a $output metrics.txt
-                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Avg. CPU Utilization:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_CPU_AVG)" | tee -a $output metrics.txt
-                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Avg. Power [Watts]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_POWER_AVG)" | tee -a $output metrics.txt
-                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Duration [seconds]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_TIME)" | tee -a $output metrics.txt
+                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Energy Used [Joules]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_ENERGY)" | tee -a $output gitlab_metrics_file
+                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Avg. CPU Utilization:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_CPU_AVG)" | tee -a $output gitlab_metrics_file
+                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Avg. Power [Watts]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_POWER_AVG)" | tee -a $output gitlab_metrics_file
+                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Duration [seconds]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_TIME)" | tee -a $output gitlab_metrics_file
                     echo "----------------" >> $output
             else
                 echo "|$(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL)|$(eval echo \$ECO_CI_MEASUREMENT_${i}_CPU_AVG)|$(eval echo \$ECO_CI_MEASUREMENT_${i}_ENERGY)|$(eval echo \$ECO_CI_MEASUREMENT_${i}_POWER_AVG)|$(eval echo \$ECO_CI_MEASUREMENT_${i}_TIME)|" | tee -a $output $output_pr
@@ -66,14 +67,14 @@ function display_results {
 
         if [[ "$ECO_CI_SOURCE" == 'gitlab' ]]; then
             # CI_JOB_NAME is a set variable by GitLab
-            echo "\"${CI_JOB_NAME}: Energy [Joules]:\" ${total_energy}" | tee -a $output metrics.txt
-            echo "\"${CI_JOB_NAME}: Avg. CPU Utilization:\" $cpu_avg_weighted" | tee -a $output metrics.txt
-            echo "\"${CI_JOB_NAME}: Avg. Power [Watts]:\" ${total_power_avg}" | tee -a $output metrics.txt
-            echo "\"${CI_JOB_NAME}: Duration [seconds]:\" ${total_time_s}" | tee -a $output metrics.txt
+            echo "\"${CI_JOB_NAME}: Energy [Joules]:\" ${total_energy}" | tee -a $output gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Avg. CPU Utilization:\" $cpu_avg_weighted" | tee -a $output gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Avg. Power [Watts]:\" ${total_power_avg}" | tee -a $output gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Duration [seconds]:\" ${total_time_s}" | tee -a $output gitlab_metrics_file
             echo "----------------" >> $output
-            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Energy [Joules]:\" ${eco_ci_total_energy_overhead}" | tee -a $output metrics.txt
-            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Avg. Power [Watts]:\" ${eco_ci_total_power_overhead}" | tee -a $output metrics.txt
-            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Duration [seconds]:\" ${eco_ci_total_time_s_overhead}" | tee -a $output metrics.txt
+            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Energy [Joules]:\" ${eco_ci_total_energy_overhead}" | tee -a $output gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Avg. Power [Watts]:\" ${eco_ci_total_power_overhead}" | tee -a $output gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Duration [seconds]:\" ${eco_ci_total_time_s_overhead}" | tee -a $output gitlab_metrics_file
 
         else
             echo "|---|---|---|---|---|" | tee -a $output $output_pr

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -16,7 +16,7 @@ function display_results {
     local output='/tmp/eco-ci/output.txt'
     local output_pr='/tmp/eco-ci/output-pr.txt'
     # Set the GitLab metrics file path, defaulting to "./metrics.txt" if ECO_CI_GITLAB_METRICS_DIR is not set.
-    local gitlab_metrics_file="${ECO_CI_GITLAB_METRICS_DIR:-.}/metrics.txt"
+    local gitlab_metrics_file="~/metrics.txt"
 
     if [[ $(wc -l < /tmp/eco-ci/energy-total.txt) -eq 0 ]]; then
         echo 'Could not display table as no measurement data was present!' >&2

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -13,9 +13,10 @@ function display_results {
     # this will set them to an empty string if they are missing entirely
     GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-}
 
-    local output='/tmp/eco-ci/output.txt'
-    local output_pr='/tmp/eco-ci/output-pr.txt'
-    # Set the GitLab metrics file path, defaulting to "./metrics.txt" if ECO_CI_GITLAB_METRICS_DIR is not set.
+# Output files
+    local tmp_dir='/tmp/eco-ci'
+	local output="${tmp_dir}/output.txt"
+    local output_pr="${tmp_dir}/output-pr.txt" if ECO_CI_GITLAB_METRICS_DIR is not set.
     local gitlab_metrics_file="~/metrics.txt"
 
     if [[ $(wc -l < /tmp/eco-ci/energy-total.txt) -eq 0 ]]; then

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -43,10 +43,10 @@ function display_results {
         for (( i=1; i<=$ECO_CI_MEASUREMENT_COUNT; i++ )); do
             if [[ "$ECO_CI_SOURCE" == 'gitlab' ]]; then
                     # CI_JOB_NAME is a set variable by GitLab
-                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Energy Used [Joules]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_ENERGY)" | tee -a $output gitlab_metrics_file
-                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Avg. CPU Utilization:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_CPU_AVG)" | tee -a $output gitlab_metrics_file
-                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Avg. Power [Watts]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_POWER_AVG)" | tee -a $output gitlab_metrics_file
-                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Duration [seconds]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_TIME)" | tee -a $output gitlab_metrics_file
+                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Energy Used [Joules]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_ENERGY)" | tee -a $output $gitlab_metrics_file
+                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Avg. CPU Utilization:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_CPU_AVG)" | tee -a $output $gitlab_metrics_file
+                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Avg. Power [Watts]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_POWER_AVG)" | tee -a $output $gitlab_metrics_file
+                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Duration [seconds]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_TIME)" | tee -a $output $gitlab_metrics_file
                     echo "----------------" >> $output
             else
                 echo "|$(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL)|$(eval echo \$ECO_CI_MEASUREMENT_${i}_CPU_AVG)|$(eval echo \$ECO_CI_MEASUREMENT_${i}_ENERGY)|$(eval echo \$ECO_CI_MEASUREMENT_${i}_POWER_AVG)|$(eval echo \$ECO_CI_MEASUREMENT_${i}_TIME)|" | tee -a $output $output_pr
@@ -67,14 +67,14 @@ function display_results {
 
         if [[ "$ECO_CI_SOURCE" == 'gitlab' ]]; then
             # CI_JOB_NAME is a set variable by GitLab
-            echo "\"${CI_JOB_NAME}: Energy [Joules]:\" ${total_energy}" | tee -a $output gitlab_metrics_file
-            echo "\"${CI_JOB_NAME}: Avg. CPU Utilization:\" $cpu_avg_weighted" | tee -a $output gitlab_metrics_file
-            echo "\"${CI_JOB_NAME}: Avg. Power [Watts]:\" ${total_power_avg}" | tee -a $output gitlab_metrics_file
-            echo "\"${CI_JOB_NAME}: Duration [seconds]:\" ${total_time_s}" | tee -a $output gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Energy [Joules]:\" ${total_energy}" | tee -a $output $gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Avg. CPU Utilization:\" $cpu_avg_weighted" | tee -a $output $gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Avg. Power [Watts]:\" ${total_power_avg}" | tee -a $output $gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Duration [seconds]:\" ${total_time_s}" | tee -a $output $gitlab_metrics_file
             echo "----------------" >> $output
-            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Energy [Joules]:\" ${eco_ci_total_energy_overhead}" | tee -a $output gitlab_metrics_file
-            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Avg. Power [Watts]:\" ${eco_ci_total_power_overhead}" | tee -a $output gitlab_metrics_file
-            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Duration [seconds]:\" ${eco_ci_total_time_s_overhead}" | tee -a $output gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Energy [Joules]:\" ${eco_ci_total_energy_overhead}" | tee -a $output $gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Avg. Power [Watts]:\" ${eco_ci_total_power_overhead}" | tee -a $output $gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Duration [seconds]:\" ${eco_ci_total_time_s_overhead}" | tee -a $output $gitlab_metrics_file
 
         else
             echo "|---|---|---|---|---|" | tee -a $output $output_pr

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -13,11 +13,11 @@ function display_results {
     # this will set them to an empty string if they are missing entirely
     GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-}
 
-# Output files
-    local tmp_dir='/tmp/eco-ci'
+	# Output files
+	local tmp_dir='/tmp/eco-ci'
 	local output="${tmp_dir}/output.txt"
-    local output_pr="${tmp_dir}/output-pr.txt" if ECO_CI_GITLAB_METRICS_DIR is not set.
-    local gitlab_metrics_file="~/metrics.txt"
+    local output_pr="${tmp_dir}/output-pr.txt"
+    local gitlab_metrics_file="${tmp_dir}/metrics.txt" # only available in gitlab instances
 
     if [[ $(wc -l < /tmp/eco-ci/energy-total.txt) -eq 0 ]]; then
         echo 'Could not display table as no measurement data was present!' >&2

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -14,8 +14,9 @@ function display_results {
     GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-}
 
     local output='/tmp/eco-ci/output.txt'
-	local gitlab_metrics_file="${CI_PROJECT_DIR}/metrics.txt"
     local output_pr='/tmp/eco-ci/output-pr.txt'
+    # Set the GitLab metrics file path, defaulting to "./metrics.txt" if ECO_CI_GITLAB_METRICS_DIR is not set.
+    local gitlab_metrics_file="${ECO_CI_GITLAB_METRICS_DIR:-.}/metrics.txt"
 
     if [[ $(wc -l < /tmp/eco-ci/energy-total.txt) -eq 0 ]]; then
         echo 'Could not display table as no measurement data was present!' >&2


### PR DESCRIPTION
`metrics.txt` was previously saved in `display_results.sh` in the current working directory. If you navigated to other directories in the pipeline before executing `display_results.sh`, `metrics.txt` was stored in the last directory.

By introducing the environment variable `ECO_CI_GITLAB_METRICS_DIR`, the directory in which `metrics.txt` is to be saved can be defined. Still, as the default the current directory is used, which means that the change is backwards-compatible.

An alternative option would be to save `metrics.txt` under `/tmp/eco-ci` like the other files, so that users can copy the file to the correct location in their own script. Personally, I like the solution with the variable better.

If this change is approved, I will update the README to reflect the new functionality.