### PR TITLE
Docs: Clarify script usage, add setup files, improve README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,100 @@
-.idea/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule.*
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.envrc
+# direnv
+.direnv/
+# virtualenv
+.direnv/python-*
+
+# Microsoft VS Code
+.vscode/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+# Python dependencies required by the eco-ci shell scripts
+psutil
+requests
+pandas
+numpy
+# argparse is standard library
+py-cpuinfo
+PyYAML
+python-dotenv
+codecarbon


### PR DESCRIPTION
Hi,
When trying to set up this repo locally, I found `pip install .` doesn't work (missing `setup.py`/`pyproject.toml`), indicating the main usage is running the shell scripts directly, especially in CI. I also noticed local script execution needs specific arguments/environment variables which wasn't detailed.

To help clarify setup, I've made these improvements:

1.  **Updated `README.md`:** Clarified the script-based/CI usage model, fixed install steps (focusing on cloning + `requirements.txt`), added a Dependencies section, and improved local execution guidance (mentioning args/env vars needed).
2.  **Added `requirements.txt`:** Makes it easy to install the Python libraries used by the scripts (`pip install -r requirements.txt`).
3.  **Improved `.gitignore`:** Replaced the minimal version with a standard Python one.


My aim was to make it easier for users to understand how to set up and run this useful toolset! Amazing repo by the way.