### PR TITLE
🐛 Fix GITHUB_STEP_SUMMARY: unbound variable

### DIFF
--- a/eco-ci-gitlab.yml
+++ b/eco-ci-gitlab.yml
@@ -24,7 +24,7 @@ variables:
             if [[ -d /tmp/eco-ci ]]; then
                 rm -rf /tmp/eco-ci
             fi
-            git clone --depth 1 --single-branch --branch "${ECO_CI_CLONE_BRANCH}" https://github.com/ridaeh/eco-ci-energy-estimation /tmp/eco-ci-repo
+            git clone --depth 1 --single-branch --branch "${ECO_CI_CLONE_BRANCH}" https://github.com/green-coding-solutions/eco-ci-energy-estimation /tmp/eco-ci-repo
 
             /tmp/eco-ci-repo/scripts/setup.sh start_measurement "${ECO_CI_MACHINE_POWER_DATA}" "${CI_PIPELINE_ID}" "${CI_COMMIT_REF_NAME}" "${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}" "${CI_PROJECT_ID}" "gitlab-ci.yml" "${CI_COMMIT_SHA}" "gitlab" "${ECO_CI_SEND_DATA}" "${ECO_CI_FILTER_TYPE}" "${ECO_CI_FILTER_PROJECT}" "${ECO_CI_FILTER_MACHINE}" "${ECO_CI_FILTER_TAGS}" "${ECO_CI_CALCULATE_CO2}" "${ECO_CI_GMT_API_TOKEN}" "${ECO_CI_ELECTRICITYMAPS_API_TOKEN}" "${ECO_CI_JSON_OUTPUT}" "${ECO_CI_API_ENDPOINT_ADD}" "${ECO_CI_API_BADGE_GET}" "${ECO_CI_DASHBOARD_URL}"
 


### PR DESCRIPTION
In Gitlab CI , using eco-ci fails with unbound variable  for GITHUB_STEP_SUMMARY if the mesured points are less than the expected mesures.

Here is the trace log for the error:

```
$ /tmp/eco-ci-repo/scripts/make_measurement.sh make_measurement "${ECO_CI_LABEL}"
Warning -  Missing data points. Expected 104 (-1) but got 100 - Data will be backfilled
/tmp/eco-ci-repo/scripts/make_measurement.sh: line 96: GITHUB_STEP_SUMMARY: unbound variable
```

This is can easly mitigated by initializing the variables with make_interface methode before accessing the GITHUB_STEP_SUMMARY in line 96.

Thanks