### PR TITLE
(fix): CPU Utilization weigthed average for display in table was computed wrongly

### DIFF
--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -37,7 +37,7 @@ function display_results {
     for (( i=1; i<=$ECO_CI_MEASUREMENT_COUNT; i++ )); do
         total_energy=$(eval echo \$ECO_CI_MEASUREMENT_${i}_ENERGY $total_energy | awk '{printf "%.2f", $1 + $2}')
         total_time_s=$(eval echo \$ECO_CI_MEASUREMENT_${i}_TIME $total_time_s | awk '{printf "%.2f", $1 + $2}')
-        total_cpu_avg_weighted=$(eval echo \$ECO_CI_MEASUREMENT_${i}_CPU_AVG $total_time_s $total_cpu_avg_weighted | awk '{printf "%.2f", ($1 * $2) + $3}')
+        total_cpu_avg_weighted=$(eval echo \$ECO_CI_MEASUREMENT_${i}_CPU_AVG \$ECO_CI_MEASUREMENT_${i}_TIME $total_cpu_avg_weighted | awk '{printf "%.2f", ($1 * $2) + $3}')
     done
 
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the time-weighted CPU utilization average in the display loop: the old code multiplied each step's `CPU_AVG` by the already-accumulated `total_time_s` (which had just been updated in the same iteration) instead of that step's own duration. The fix substitutes `\$ECO_CI_MEASUREMENT_${i}_TIME` as the per-step weight, producing the correct formula `Σ(cpu_i × time_i) / Σtime_i`.

<sub>Reviews (1): Last reviewed commit: ["(fix): CPU Utilization weigthed average ..."](https://github.com/green-coding-solutions/eco-ci-energy-estimation/commit/90f9dbc13784bf17d1575e4353fa0025604c1e3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28758897)</sub>

<!-- /greptile_comment -->