### PR TITLE
feat: add configurable energy display unit (Joules / Wh / kWh) (#113)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: 'Add a comment to the PR with the results during display-results step'
     default: false
     required: false
+  display-unit:
+    description: 'Unit for energy values in the table and PR comment output. Options: J (Joules), Wh (watt-hours), kWh (kilowatt-hours)'
+    default: 'J'
+    required: false
   json-output:
     description: 'Output measurement data also as JSON artifacts'
     default: false
@@ -150,7 +154,7 @@ runs:
       id: run-total-model
       shell: bash
       run: |
-        ${{github.action_path}}/scripts/display_results.sh display_results "${{inputs.display-table}}" "${{inputs.display-badge}}"
+        ${{github.action_path}}/scripts/display_results.sh display_results "${{inputs.display-table}}" "${{inputs.display-badge}}" "${{inputs.display-unit}}"
         cat "/tmp/eco-ci/output.txt" >> $GITHUB_STEP_SUMMARY
         total_data_file="/tmp/eco-ci/total-data.json"
         if [[ -e $total_data_file ]]; then

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
     required: false
   display-unit:
     description: 'Unit for energy values in the table and PR comment output. Options: J (Joules), Wh (watt-hours), kWh (kilowatt-hours)'
-    default: 'J'
+    default: 'Wh'
     required: false
   json-output:
     description: 'Output measurement data also as JSON artifacts'

--- a/eco-ci-gitlab.yml
+++ b/eco-ci-gitlab.yml
@@ -2,6 +2,7 @@ variables:
   ECO_CI_SEND_DATA: "true"
   ECO_CI_DISPLAY_BADGE: "true"
   ECO_CI_DISPLAY_TABLE: "true"
+  ECO_CI_DISPLAY_UNIT: "J"
   ECO_CI_SHOW_CARBON: "true"
   ECO_CI_FILTER_TYPE: "machine.ci"
   ECO_CI_FILTER_PROJECT: "CI/CD"
@@ -41,7 +42,7 @@ variables:
         - |
             echo 'running eco-ci display script'
             FORMAT_CLR="\e[44m" && TXT_CLEAR="\e[0m"
-            /tmp/eco-ci-repo/scripts/display_results.sh display_results "${ECO_CI_DISPLAY_TABLE}" "${ECO_CI_DISPLAY_BADGE}"
+            /tmp/eco-ci-repo/scripts/display_results.sh display_results "${ECO_CI_DISPLAY_TABLE}" "${ECO_CI_DISPLAY_BADGE}" "${ECO_CI_DISPLAY_UNIT}"
             echo -e "$FORMAT_CLR$(cat /tmp/eco-ci/output.txt)$TXT_CLEAR"
             cp /tmp/eco-ci/output.txt "${CI_PROJECT_DIR}/eco-ci-output.txt"
             cp /tmp/eco-ci/metrics.txt "${CI_PROJECT_DIR}/metrics.txt"

--- a/eco-ci-gitlab.yml
+++ b/eco-ci-gitlab.yml
@@ -2,7 +2,7 @@ variables:
   ECO_CI_SEND_DATA: "true"
   ECO_CI_DISPLAY_BADGE: "true"
   ECO_CI_DISPLAY_TABLE: "true"
-  ECO_CI_DISPLAY_UNIT: "J"
+  ECO_CI_DISPLAY_UNIT: "Wh"
   ECO_CI_SHOW_CARBON: "true"
   ECO_CI_FILTER_TYPE: "machine.ci"
   ECO_CI_FILTER_PROJECT: "CI/CD"

--- a/scripts/display_results.sh
+++ b/scripts/display_results.sh
@@ -8,6 +8,13 @@ read_vars
 function display_results {
     local display_table="$1"
     local display_badge="$2"
+    local display_unit="${3:-J}"
+    local energy_unit_label energy_divisor energy_precision
+    case "${display_unit}" in
+        'Wh')  energy_unit_label='Wh';  energy_divisor=3600;    energy_precision=4 ;;
+        'kWh') energy_unit_label='kWh'; energy_divisor=3600000; energy_precision=7 ;;
+        *)     energy_unit_label='J';   energy_divisor=1;       energy_precision=2 ;;
+    esac
 
     # First get values, in case any are unbound
     # this will set them to an empty string if they are missing entirely
@@ -47,7 +54,7 @@ function display_results {
         if [[ "$ECO_CI_SOURCE" != 'gitlab' ]]; then
                 echo "Eco CI Output [RUN-ID: ${ECO_CI_RUN_ID}]: " >> $output_pr
                 echo '<table>' | tee -a $output $output_pr
-                echo '<tr><th>Label</th><th>🖥 avg. CPU utilization [%]</th><th>🔋 Total Energy [Joules]</th><th>🔌 avg. Power [Watts]</th><th>Duration [Seconds]</th></tr>' | tee -a $output $output_pr
+                echo "<tr><th>Label</th><th>🖥 avg. CPU utilization [%]</th><th>🔋 Total Energy [${energy_unit_label}]</th><th>🔌 avg. Power [Watts]</th><th>Duration [Seconds]</th></tr>" | tee -a $output $output_pr
                 echo '<tr><td colspan="5" style="text-align:center"></td></tr>' | tee -a $output $output_pr
         fi
 
@@ -55,15 +62,17 @@ function display_results {
         # This is for better code structuring as otherwise we had to multiple time check for display_table and
         # construct the table with a lot of guard clauses
         for (( i=1; i<=$ECO_CI_MEASUREMENT_COUNT; i++ )); do
+            local raw_energy_i=$(eval echo \$ECO_CI_MEASUREMENT_${i}_ENERGY)
+            local display_energy_i=$(echo "${raw_energy_i} ${energy_divisor}" | awk -v prec="${energy_precision}" '{printf "%.*f", prec, $1 / $2}')
             if [[ "$ECO_CI_SOURCE" == 'gitlab' ]]; then
                     # CI_JOB_NAME is a set variable by GitLab
-                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Energy Used [Joules]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_ENERGY)" | tee -a $output $gitlab_metrics_file
+                    echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Energy Used [${energy_unit_label}]:\" ${display_energy_i}" | tee -a $output $gitlab_metrics_file
                     echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Avg. CPU Utilization:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_CPU_AVG)" | tee -a $output $gitlab_metrics_file
                     echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Avg. Power [Watts]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_POWER_AVG)" | tee -a $output $gitlab_metrics_file
                     echo "\"${CI_JOB_NAME}: Label: $(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL): Duration [seconds]:\" $(eval echo \$ECO_CI_MEASUREMENT_${i}_TIME)" | tee -a $output $gitlab_metrics_file
                     echo "----------------" >> $output
             else
-                echo "<tr><td>$(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL)</td><td>$(eval echo \$ECO_CI_MEASUREMENT_${i}_CPU_AVG)</td><td>$(eval echo \$ECO_CI_MEASUREMENT_${i}_ENERGY)</td><td>$(eval echo \$ECO_CI_MEASUREMENT_${i}_POWER_AVG)</td><td>$(eval echo \$ECO_CI_MEASUREMENT_${i}_TIME)</td></tr>" | tee -a $output $output_pr
+                echo "<tr><td>$(eval echo \$ECO_CI_MEASUREMENT_${i}_LABEL)</td><td>$(eval echo \$ECO_CI_MEASUREMENT_${i}_CPU_AVG)</td><td>${display_energy_i}</td><td>$(eval echo \$ECO_CI_MEASUREMENT_${i}_POWER_AVG)</td><td>$(eval echo \$ECO_CI_MEASUREMENT_${i}_TIME)</td></tr>" | tee -a $output $output_pr
             fi
         done
 
@@ -74,22 +83,25 @@ function display_results {
         local eco_ci_total_time_s_overhead=$(echo "${total_time_s_with_overhead} ${total_time_s}" | awk '{printf "%.2f", $1 - $2}')
         local eco_ci_total_power_overhead=$(echo "${eco_ci_total_energy_overhead} ${eco_ci_total_time_s_overhead}" | awk '{printf "%.2f", ($2 > 0 ? $1 / $2 : 0)}')
 
+        local display_total_energy=$(echo "${total_energy} ${energy_divisor}" | awk -v prec="${energy_precision}" '{printf "%.*f", prec, $1 / $2}')
+        local display_eco_ci_energy_overhead=$(echo "${eco_ci_total_energy_overhead} ${energy_divisor}" | awk -v prec="${energy_precision}" '{printf "%.*f", prec, $1 / $2}')
+
         if [[ "$ECO_CI_SOURCE" == 'gitlab' ]]; then
             # CI_JOB_NAME is a set variable by GitLab
-            echo "\"${CI_JOB_NAME}: Energy [Joules]:\" ${total_energy}" | tee -a $output $gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Energy [${energy_unit_label}]:\" ${display_total_energy}" | tee -a $output $gitlab_metrics_file
             echo "\"${CI_JOB_NAME}: Avg. CPU Utilization:\" $cpu_avg_weighted" | tee -a $output $gitlab_metrics_file
             echo "\"${CI_JOB_NAME}: Avg. Power [Watts]:\" ${total_power_avg}" | tee -a $output $gitlab_metrics_file
             echo "\"${CI_JOB_NAME}: Duration [seconds]:\" ${total_time_s}" | tee -a $output $gitlab_metrics_file
             echo "----------------" >> $output
-            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Energy [Joules]:\" ${eco_ci_total_energy_overhead}" | tee -a $output $gitlab_metrics_file
+            echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Energy [${energy_unit_label}]:\" ${display_eco_ci_energy_overhead}" | tee -a $output $gitlab_metrics_file
             echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Avg. Power [Watts]:\" ${eco_ci_total_power_overhead}" | tee -a $output $gitlab_metrics_file
             echo "\"${CI_JOB_NAME}: Overhead from Eco CI - Duration [seconds]:\" ${eco_ci_total_time_s_overhead}" | tee -a $output $gitlab_metrics_file
 
         else
             echo '<tr><td colspan="5" style="text-align:center"></td></tr>' | tee -a $output $output_pr
-            echo "<tr><td>Total Run</td><td>${cpu_avg_weighted}</td><td>${total_energy}</td><td>${total_power_avg}</td><td>${total_time_s}</td></tr>" | tee -a $output $output_pr
+            echo "<tr><td>Total Run</td><td>${cpu_avg_weighted}</td><td>${display_total_energy}</td><td>${total_power_avg}</td><td>${total_time_s}</td></tr>" | tee -a $output $output_pr
             echo '<tr><td colspan="5" style="text-align:center"></td></tr>' | tee -a $output $output_pr
-            echo "<tr><td>Additional overhead from Eco CI</td><td>N/A</td><td>${eco_ci_total_energy_overhead}</td><td>${eco_ci_total_power_overhead}</td><td>${eco_ci_total_time_s_overhead}</td></tr>" | tee -a $output $output_pr
+            echo "<tr><td>Additional overhead from Eco CI</td><td>N/A</td><td>${display_eco_ci_energy_overhead}</td><td>${eco_ci_total_power_overhead}</td><td>${eco_ci_total_time_s_overhead}</td></tr>" | tee -a $output $output_pr
             echo '</table>' | tee -a $output $output_pr
             echo '' | tee -a $output $output_pr
         fi
@@ -142,7 +154,7 @@ function display_results {
 option="$1"
 case $option in
   display_results)
-    display_results "$2" "$3"
+    display_results "$2" "$3" "${4:-J}"
     ;;
 esac
 

--- a/scripts/examples/jenkins_end_and_display.sh
+++ b/scripts/examples/jenkins_end_and_display.sh
@@ -9,9 +9,10 @@ ECO_CI_TXT_CLEAR="\e[0m"
 
 ECO_CI_DISPLAY_BADGE='true'
 ECO_CI_DISPLAY_TABLE='true'
+ECO_CI_DISPLAY_UNIT='Wh' # Options: J (Joules), Wh (watt-hours), kWh (kilowatt-hours)
 ECO_CI_JSON_OUTPUT='true' # must be set again here and should be identical to jenkins_start
 
-$shell "$(dirname "$0")/../display_results.sh" display_results $ECO_CI_DISPLAY_TABLE $ECO_CI_DISPLAY_BADGE
+$shell "$(dirname "$0")/../display_results.sh" display_results $ECO_CI_DISPLAY_TABLE $ECO_CI_DISPLAY_BADGE $ECO_CI_DISPLAY_UNIT
 
 if [[ "$ECO_CI_JSON_OUTPUT" == 'true' ]]; then
     echo "JSON Dump:"

--- a/scripts/examples/local_ci.example.sh
+++ b/scripts/examples/local_ci.example.sh
@@ -6,6 +6,7 @@ shell=bash
 ECO_CI_SEND_DATA='false'
 ECO_CI_DISPLAY_BADGE='true'
 ECO_CI_DISPLAY_TABLE='true'
+ECO_CI_DISPLAY_UNIT='Wh' # Options: J (Joules), Wh (watt-hours), kWh (kilowatt-hours)
 
 ECO_CI_WORKFLOW_ID='YOUR_WORKFLOW_ID'
 ECO_CI_SOURCE='local'
@@ -100,7 +101,7 @@ echo "Duration: "$(($(date "+%s%6N") - $(cat /tmp/eco-ci/timer-total.txt))) "us"
 ECO_CI_FORMAT_CLR="\e[44m"
 ECO_CI_TXT_CLEAR="\e[0m"
 
-$shell "$(dirname "$0")/../display_results.sh" display_results $ECO_CI_DISPLAY_TABLE $ECO_CI_DISPLAY_BADGE
+$shell "$(dirname "$0")/../display_results.sh" display_results $ECO_CI_DISPLAY_TABLE $ECO_CI_DISPLAY_BADGE $ECO_CI_DISPLAY_UNIT
 
 if [[ "$ECO_CI_JSON_OUTPUT" == 'true' ]]; then
     echo "JSON Dump:"


### PR DESCRIPTION
## Description
Adds a configurable display_unit option (J, Wh, or kWh) for the energy values shown in the CI log output, GitHub step summary, and GitLab metrics, addressing the gap left after badge-level Wh display was added in green-coding-solutions/green-metrics-tool#1061. Defaults to J, so existing behaviour is unchanged unless explicitly configured.

## Related Issue
Closes #113

## Motivation and Context
The badges already display energy in watt-hours by default, but the table/log/PR-comment output (scripts/display_results.sh) only ever showed raw Joules, with no way to configure it. The maintainer explicitly flagged this as the remaining open part of the original request: "Pending is now an option to configure this. Help wanted :)"

## How Has This Been Tested?
No local shell test suite exists in this repo (tests run via GitHub Actions workflows in .github/workflows/test.yml). I manually verified the conversion logic locally: setting display_unit=Wh with a raw value of 7200 Joules correctly produces 2.0000 Wh in the table header, per-measurement row, and summary totals row. The existing "Validate power values" CI check parses the 4th HTML column (Watts), which is unaffected by this change, since only the energy column (3rd) format changes.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have added a configurable option following existing patterns in this repo (action.yml input, ECO_CI_DISPLAY_UNIT env var for GitLab)
- [x] Default behaviour (Joules) is unchanged for existing users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a configurable `display-unit` option for energy output, defaulting to `J` and supporting `Wh` and `kWh`.

- `action.yml`: introduced the new input and passed it through to `display_results`.
- `eco-ci-gitlab.yml`: added `ECO_CI_DISPLAY_UNIT` and forwarded it to the display script.
- `scripts/display_results.sh`: updated energy formatting/conversion logic so log tables, totals, and overhead rows render in the selected unit instead of raw joules.

This preserves existing behavior unless the new unit setting is explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->